### PR TITLE
OpenGL2: Fix FB-MSAA on AMD Windows driver

### DIFF
--- a/code/renderergl2/tr_fbo.c
+++ b/code/renderergl2/tr_fbo.c
@@ -170,8 +170,12 @@ void FBO_CreateBuffer(FBO_t *fbo, int format, int index, int multisample)
 	}
 
 	absent = *pRenderBuffer == 0;
-	if (absent)
+	if (absent) {
 		qglGenRenderbuffers(1, pRenderBuffer);
+
+		// workaround AMD Windows driver requiring bind to create renderbuffer
+		GL_BindRenderbuffer(*pRenderBuffer);
+	}
 
 	if (multisample && glRefConfig.framebufferMultisample)
 		qglNamedRenderbufferStorageMultisampleEXT(*pRenderBuffer, multisample, format, fbo->width, fbo->height);


### PR DESCRIPTION
Fix r_ext_framebuffer_multisample > 0 causing the screen to always be solid black when using AMD Windows driver.

The AMD Windows driver requires binding renderbuffer for it to be valid. The OpenGL2 renderer uses GL_EXT_direct_state_access that shouldn't require this. It would be required for Core/GL_ARB_direct_state_access. It seems like a driver bug.